### PR TITLE
Add YAML file generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	github.com/urfave/cli v1.20.0
 	golang.org/x/net v0.0.0-20181005035420-146acd28ed58 // indirect
 	google.golang.org/grpc v1.15.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -62,4 +62,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.15.0 h1:Az/KuahOM4NAidTEuJCv/RonAA7rYsTPkqXVjr+8OOw=
 google.golang.org/grpc v1.15.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -59,6 +59,21 @@ func main() {
 			},
 		},
 		{
+			Name:   "generate-yaml",
+			Usage:  "generate evaluated jsonnet content into single YAML file",
+			Action: generateYaml,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "source, s",
+					Usage: "load service definition from `FILE`",
+				},
+				cli.StringFlag{
+					Name:  "output, o",
+					Usage: "write YAML to `FILE`",
+				},
+			},
+		},
+		{
 			Name:    "server",
 			Aliases: []string{"s"},
 			Usage:   "run xDS POST-GET convert proxy",
@@ -140,6 +155,20 @@ func generate(ctx *cli.Context) error {
 	}
 
 	return generator.Generate(opts)
+}
+
+func generateYaml(ctx *cli.Context) error {
+	source := ctx.String("source")
+	if len(source) < 1 {
+		return buildEmptyFlagError("source")
+	}
+
+	output := ctx.String("output")
+	if len(output) < 1 {
+		return buildEmptyFlagError("output")
+	}
+
+	return generator.GenerateYaml(source, output)
 }
 
 func serverCmd(ctx *cli.Context) error {


### PR DESCRIPTION
Like:

```
~/.ghq/github.com/cookpad/itacho add-yaml-generator
✔ ./itacho generate-yaml -s example/book.jsonnet -o tmp/book.yaml
INFO[0000] Generated YAML file: tmp/book.yaml

~/.ghq/github.com/cookpad/itacho add-yaml-generator
✔ head tmp/book.yaml
dependencies:
- circuit_breaker:
    max_connections: 64
    max_pending_requests: 128
    max_retries: 3
  cluster_name: user-development
  connect_timeout_ms: 250
  host_header: user-service
  lb: user-app:8080
  name: user
```

@cookpad/infra @cookpad/dev-infra FYI