### PR TITLE
Fix overflow in per_try_timeout_ms

### DIFF
--- a/generator/rds.go
+++ b/generator/rds.go
@@ -185,7 +185,7 @@ func buildFaultDelayConfig(faultDelay *config.FaultDelay) *types.Value {
 func buildRoute(dep *config.Dependency, timeout *time.Duration, m route.RouteMatch, retryConfig *config.RetryPolicy) route.Route {
 	var policy *route.RouteAction_RetryPolicy
 	if retryConfig != nil {
-		perTryTimeout := time.Duration(retryConfig.GetPerTryTimeoutMs()*1000*1000) * time.Nanosecond
+		perTryTimeout := time.Duration(retryConfig.GetPerTryTimeoutMs()) * time.Millisecond
 		policy = &route.RouteAction_RetryPolicy{
 			RetryOn:       retryConfig.GetRetryOn(),
 			NumRetries:    &types.UInt32Value{Value: retryConfig.GetNumRetries()},


### PR DESCRIPTION
`retryConfig.GetPerTryTimeoutMs()*1000*1000` overflows when
per_try_timeout_ms is greater than 4294 because per_try_timeout_ms has
type `uint32`.

@taiki45 @cookpad/infra please review