### PR TITLE
Use dev base image for test/grpc

### DIFF
--- a/test/grpc/Dockerfile
+++ b/test/grpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/sorah/ruby:3.2-jammy
+FROM public.ecr.aws/sorah/ruby:3.2-dev-jammy
 
 RUN mkdir /app
 COPY Gemfile Gemfile.lock /app/


### PR DESCRIPTION
In arm64 environment, grpc gem needs to be built from source, thus ruby-dev is required.

@cookpad/infra would you please review?