### PR TITLE
Allow unknown fields in DiscoveryRequest

### DIFF
--- a/xds/v2/xds.go
+++ b/xds/v2/xds.go
@@ -1,6 +1,7 @@
 package xds
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -29,7 +30,8 @@ func ExtractNodeCluster(node *envoy_api_v2_core.Node) string {
 // UnmarshalDiscoveryRequest build Envoy's DiscoveryRequest proto message from JSON string
 func UnmarshalDiscoveryRequest(typeURL string, body *[]byte) (*envoy_api_v2.DiscoveryRequest, error) {
 	req := &envoy_api_v2.DiscoveryRequest{}
-	if err := jsonpb.UnmarshalString(string(*body), req); err != nil {
+	unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
+	if err := unmarshaler.Unmarshal(bytes.NewReader(*body), req); err != nil {
 		return nil, fmt.Errorf("Failed parse JSON body: %s", err)
 	}
 	req.TypeUrl = typeURL

--- a/xds/v3/xds.go
+++ b/xds/v3/xds.go
@@ -1,6 +1,7 @@
 package xds
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -29,7 +30,8 @@ func ExtractNodeCluster(node *envoy_config_core_v3.Node) string {
 // UnmarshalDiscoveryRequest build Envoy's DiscoveryRequest proto message from JSON string
 func UnmarshalDiscoveryRequest(typeURL string, body *[]byte) (*envoy_service_discovery_v3.DiscoveryRequest, error) {
 	req := &envoy_service_discovery_v3.DiscoveryRequest{}
-	if err := jsonpb.UnmarshalString(string(*body), req); err != nil {
+	unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
+	if err := unmarshaler.Unmarshal(bytes.NewReader(*body), req); err != nil {
 		return nil, fmt.Errorf("Failed parse JSON body: %s", err)
 	}
 	req.TypeUrl = typeURL


### PR DESCRIPTION
Current implementation uses `jsonpb.UnmarshalString` to decode DiscoveryRequest, that results in failure on unknown field.
https://github.com/golang/protobuf/blob/v1.4.0/jsonpb/decode.go#L38

For example, Envoy v1.23 or later includes `type_urls` field in `config.core.v3.Extension`, but the field is not known in go-control-plane v0.9.5 (that is generated from protos around Envoy v1.14). This disables usage of itacho with Envoy v1.23 or later.
https://www.envoyproxy.io/docs/envoy/v1.23.0/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-extension

This PR changes the implementation to ignore unknown field in unmarshaling DiscoveryRequest to gain compatibility with Envoy v1.23. We could also have updatd go-control-plane to the latest version, but I put it off as it involves removal of v2 support.

@cookpad/infra Would you please review?